### PR TITLE
remove pngtest.c references

### DIFF
--- a/xcode/libpng.xcodeproj/project.pbxproj
+++ b/xcode/libpng.xcodeproj/project.pbxproj
@@ -41,8 +41,6 @@
 		A55DFBAF15EBB557007CCF00 /* pngwrite.c in Sources */ = {isa = PBXBuildFile; fileRef = 14461C6E09C3C37F005840C0 /* pngwrite.c */; };
 		A55DFBB015EBB557007CCF00 /* pngwtran.c in Sources */ = {isa = PBXBuildFile; fileRef = 14461C6F09C3C37F005840C0 /* pngwtran.c */; };
 		A55DFBB115EBB557007CCF00 /* pngwutil.c in Sources */ = {isa = PBXBuildFile; fileRef = 14461C7009C3C37F005840C0 /* pngwutil.c */; };
-		A5A58CD317CF752A00B64330 /* pngtest.c in Sources */ = {isa = PBXBuildFile; fileRef = A5A58CD217CF752A00B64330 /* pngtest.c */; };
-		A5A58CD417CF752A00B64330 /* pngtest.c in Sources */ = {isa = PBXBuildFile; fileRef = A5A58CD217CF752A00B64330 /* pngtest.c */; };
 		A5A58CDB17CF754800B64330 /* pnginfo.h in Headers */ = {isa = PBXBuildFile; fileRef = A5A58CD717CF754800B64330 /* pnginfo.h */; };
 		A5A58CDC17CF754800B64330 /* pngpriv.h in Headers */ = {isa = PBXBuildFile; fileRef = A5A58CD817CF754800B64330 /* pngpriv.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A5A58CDD17CF754800B64330 /* pngstruct.h in Headers */ = {isa = PBXBuildFile; fileRef = A5A58CD917CF754800B64330 /* pngstruct.h */; };
@@ -62,7 +60,6 @@
 		A5A58CF417CF7FBE00B64330 /* pngwrite.c in Sources */ = {isa = PBXBuildFile; fileRef = 14461C6E09C3C37F005840C0 /* pngwrite.c */; };
 		A5A58CF517CF7FBE00B64330 /* pngwtran.c in Sources */ = {isa = PBXBuildFile; fileRef = 14461C6F09C3C37F005840C0 /* pngwtran.c */; };
 		A5A58CF617CF7FBE00B64330 /* pngwutil.c in Sources */ = {isa = PBXBuildFile; fileRef = 14461C7009C3C37F005840C0 /* pngwutil.c */; };
-		A5A58CF717CF7FBE00B64330 /* pngtest.c in Sources */ = {isa = PBXBuildFile; fileRef = A5A58CD217CF752A00B64330 /* pngtest.c */; };
 		A5BFDBA11A97359D007A9234 /* mac_libpng_test.m in Sources */ = {isa = PBXBuildFile; fileRef = A5BFDBA01A97359D007A9234 /* mac_libpng_test.m */; };
 		A5BFDBA21A97359D007A9234 /* libpng.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8D07F2C80486CC7A007CD1D0 /* libpng.framework */; };
 		A5BFDBAC1A97377F007A9234 /* png.h in Headers */ = {isa = PBXBuildFile; fileRef = 14461C5E09C3C37F005840C0 /* png.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -144,7 +141,6 @@
 		8D07F2C80486CC7A007CD1D0 /* libpng.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = libpng.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A55DFB5515EBB10D007CCF00 /* pnglibconf.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pnglibconf.h; path = ../../pnglibconf.h; sourceTree = "<group>"; };
 		A55DFB7815EBB44B007CCF00 /* libpng.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libpng.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		A5A58CD217CF752A00B64330 /* pngtest.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pngtest.c; path = ../../pngtest.c; sourceTree = "<group>"; };
 		A5A58CD717CF754800B64330 /* pnginfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pnginfo.h; path = ../../pnginfo.h; sourceTree = "<group>"; };
 		A5A58CD817CF754800B64330 /* pngpriv.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pngpriv.h; path = ../../pngpriv.h; sourceTree = "<group>"; };
 		A5A58CD917CF754800B64330 /* pngstruct.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pngstruct.h; path = ../../pngstruct.h; sourceTree = "<group>"; };
@@ -256,7 +252,6 @@
 		A55DFB6E15EBB2A3007CCF00 /* src */ = {
 			isa = PBXGroup;
 			children = (
-				A5A58CD217CF752A00B64330 /* pngtest.c */,
 				14461C5D09C3C37F005840C0 /* png.c */,
 				14461C6009C3C37F005840C0 /* pngerror.c */,
 				14461C6209C3C37F005840C0 /* pngget.c */,
@@ -624,7 +619,6 @@
 				14461C8209C3C37F005840C0 /* pngwrite.c in Sources */,
 				14461C8309C3C37F005840C0 /* pngwtran.c in Sources */,
 				14461C8409C3C37F005840C0 /* pngwutil.c in Sources */,
-				A5A58CD317CF752A00B64330 /* pngtest.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -647,7 +641,6 @@
 				A55DFBAF15EBB557007CCF00 /* pngwrite.c in Sources */,
 				A55DFBB015EBB557007CCF00 /* pngwtran.c in Sources */,
 				A55DFBB115EBB557007CCF00 /* pngwutil.c in Sources */,
-				A5A58CD417CF752A00B64330 /* pngtest.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -670,7 +663,6 @@
 				A5A58CF417CF7FBE00B64330 /* pngwrite.c in Sources */,
 				A5A58CF517CF7FBE00B64330 /* pngwtran.c in Sources */,
 				A5A58CF617CF7FBE00B64330 /* pngwutil.c in Sources */,
-				A5A58CF717CF7FBE00B64330 /* pngtest.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
When using "-ObjC -all_load" linker option on the application using the library, build failed.
because pngtest.c contains main() method. ( duplicate main() method)

Why using "-all_load" option: 
https://developer.apple.com/library/mac/qa/qa1490/_index.html
